### PR TITLE
C++: NonConstantFormat taint only for string types

### DIFF
--- a/cpp/ql/test/query-tests/Likely Bugs/Format/NonConstantFormat/NonConstantFormat.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/NonConstantFormat/NonConstantFormat.expected
@@ -18,3 +18,4 @@
 | test.cpp:85:12:85:16 | hello | The format string argument to printf should be constant to prevent security issues and other potential errors. |
 | test.cpp:90:12:90:18 | ++ ... | The format string argument to printf should be constant to prevent security issues and other potential errors. |
 | test.cpp:107:12:107:24 | new[] | The format string argument to printf should be constant to prevent security issues and other potential errors. |
+| test.cpp:142:10:142:20 | access to array | The format string argument to printf should be constant to prevent security issues and other potential errors. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/NonConstantFormat/NonConstantFormat.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/NonConstantFormat/NonConstantFormat.expected
@@ -18,4 +18,3 @@
 | test.cpp:85:12:85:16 | hello | The format string argument to printf should be constant to prevent security issues and other potential errors. |
 | test.cpp:90:12:90:18 | ++ ... | The format string argument to printf should be constant to prevent security issues and other potential errors. |
 | test.cpp:107:12:107:24 | new[] | The format string argument to printf should be constant to prevent security issues and other potential errors. |
-| test.cpp:142:10:142:20 | access to array | The format string argument to printf should be constant to prevent security issues and other potential errors. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/NonConstantFormat/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/NonConstantFormat/test.cpp
@@ -133,3 +133,11 @@ void another_func(void) {
   printf("Hello, World\n"); // GOOD
   printf(gettext("Hello, World\n")); // GOOD
 }
+
+void set_value_of(int *i);
+
+void print_ith_message() {
+  int i;
+  set_value_of(&i);
+  printf(messages[i], 1U); // GOOD [FALSE POSITIVE]
+}

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/NonConstantFormat/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/NonConstantFormat/test.cpp
@@ -139,5 +139,5 @@ void set_value_of(int *i);
 void print_ith_message() {
   int i;
   set_value_of(&i);
-  printf(messages[i], 1U); // GOOD [FALSE POSITIVE]
+  printf(messages[i], 1U); // GOOD
 }


### PR DESCRIPTION
The first commit reproduces the array-access FP we've seen in the wild, and the second commit fixes it. I want to also stop the taint tracking library from propagating taint from `i` to `a[i]`, but that will be a separate PR.